### PR TITLE
Feat: Modularize job result handler

### DIFF
--- a/ergo-annotations/src/main/kotlin/headout/oss/ergo/annotations/Task.kt
+++ b/ergo-annotations/src/main/kotlin/headout/oss/ergo/annotations/Task.kt
@@ -4,6 +4,16 @@ package headout.oss.ergo.annotations
  * Created by shivanshs9 on 20/05/20.
  */
 
+/**
+ * Task annotation to use on any function denoting it as Ergo Task
+ * with the given [taskId]. All functions annotated with this are processed
+ * and generated on compile-time, validating the request arguments.
+ *
+ * It can be used for both regular and suspending functions.
+ * Ensure that all the parameters and return type are serializable (using [Serializable] annotation on data class)
+ *
+ * @param taskId unique identifier for the given function associated with a task
+ */
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.FUNCTION)
 annotation class Task(val taskId: TaskId, val retryOnFail: Boolean = false)

--- a/ergo-runtime/src/main/kotlin/headout/oss/ergo/factory/DefaultInstanceLocator.kt
+++ b/ergo-runtime/src/main/kotlin/headout/oss/ergo/factory/DefaultInstanceLocator.kt
@@ -5,6 +5,10 @@ import kotlin.reflect.KClass
 /**
  * Created by shivanshs9 on 13/07/20.
  */
+
+/**
+ * Supports instances of singleton classes and classes with a no-arg constructor
+ */
 class DefaultInstanceLocator : InstanceLocator {
     override fun <T : Any> getInstance(clazz: KClass<T>): T? {
         return clazz.objectInstance ?: clazz.constructors.let {

--- a/ergo-runtime/src/main/kotlin/headout/oss/ergo/factory/InstanceLocator.kt
+++ b/ergo-runtime/src/main/kotlin/headout/oss/ergo/factory/InstanceLocator.kt
@@ -5,6 +5,15 @@ import kotlin.reflect.KClass
 /**
  * Created by shivanshs9 on 13/07/20.
  */
+
+/**
+ * Defines an interface to return instance of a given class
+ * Used by Ergo service to get the task's enclosing class's instance
+ * to call the task in runtime
+ *
+ * [TaskController] gets the instance using the [InstanceLocatorFactory]
+ * to locate a suitable instance for the required class
+ */
 interface InstanceLocator {
-    fun <T: Any> getInstance(clazz: KClass<T>): T?
+    fun <T : Any> getInstance(clazz: KClass<T>): T?
 }

--- a/ergo-runtime/src/main/kotlin/headout/oss/ergo/factory/InstanceLocatorFactory.kt
+++ b/ergo-runtime/src/main/kotlin/headout/oss/ergo/factory/InstanceLocatorFactory.kt
@@ -6,6 +6,11 @@ import kotlin.reflect.KClass
 /**
  * Created by shivanshs9 on 13/07/20.
  */
+
+/**
+ * Uses Java's [ServiceLoader] to try all the implementations of [InstanceLocator]
+ * to get the required instance of the given class
+ */
 object InstanceLocatorFactory : InstanceLocator {
     override fun <T : Any> getInstance(clazz: KClass<T>): T {
         val iter = ServiceLoader.load(InstanceLocator::class.java).iterator()

--- a/ergo-service-sqs/src/main/kotlin/headout/oss/ergo/helpers/ImmediateRespondJobResultHandler.kt
+++ b/ergo-service-sqs/src/main/kotlin/headout/oss/ergo/helpers/ImmediateRespondJobResultHandler.kt
@@ -1,0 +1,22 @@
+package headout.oss.ergo.helpers
+
+import headout.oss.ergo.models.JobResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * Created by shivanshs9 on 21/09/20.
+ */
+@ExperimentalCoroutinesApi
+class ImmediateRespondJobResultHandler : JobResultHandler {
+    private lateinit var implPushResults: suspend (List<JobResult<*>>) -> Unit
+
+    override fun init(scope: CoroutineScope, pushResultsImpl: suspend (List<JobResult<*>>) -> Unit) {
+        implPushResults = pushResultsImpl
+    }
+
+    override suspend fun handleResult(result: JobResult<*>): Boolean {
+        implPushResults(listOf(result))
+        return true
+    }
+}

--- a/ergo-service-sqs/src/main/kotlin/headout/oss/ergo/helpers/InMemoryBufferJobResultHandler.kt
+++ b/ergo-service-sqs/src/main/kotlin/headout/oss/ergo/helpers/InMemoryBufferJobResultHandler.kt
@@ -1,0 +1,62 @@
+package headout.oss.ergo.helpers
+
+import headout.oss.ergo.models.JobResult
+import headout.oss.ergo.services.BaseMsgService
+import headout.oss.ergo.utils.repeatUntilCancelled
+import headout.oss.ergo.utils.ticker
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.ReceiveChannel
+import mu.KotlinLogging
+import org.slf4j.MarkerFactory
+
+/**
+ * Created by shivanshs9 on 21/09/20.
+ */
+private val logger = KotlinLogging.logger {}
+
+@ExperimentalCoroutinesApi
+class InMemoryBufferJobResultHandler(private val maxResultsToBuffer: Int) : JobResultHandler {
+    private lateinit var implPushResults: suspend (List<JobResult<*>>) -> Unit
+    private lateinit var timeoutResultCollect: ReceiveChannel<Unit>
+
+    private val bufferedResults = mutableListOf<JobResult<*>>()
+
+    override fun init(scope: CoroutineScope, pushResultsImpl: suspend (List<JobResult<*>>) -> Unit) {
+        implPushResults = pushResultsImpl
+        timeoutResultCollect = scope.ticker(TIMEOUT_RESULT_COLLECTION)
+        handleBufferTimeout(scope)
+    }
+
+    override suspend fun handleResult(result: JobResult<*>): Boolean {
+        addResultToBuffer(result)
+        return if (bufferedResults.size == maxResultsToBuffer) {
+            pushAndClearBuffer()
+            true
+        } else false
+    }
+
+    private fun handleBufferTimeout(scope: CoroutineScope): Job = scope.launch(Dispatchers.IO) {
+        repeatUntilCancelled(BaseMsgService.Companion::collectCaughtExceptions) {
+            for (timeoutPing in timeoutResultCollect) {
+                logger.debug(MARKER_RESULT_BUFFER, "TIMEOUT: Result Collect!")
+                if (bufferedResults.isNotEmpty()) pushAndClearBuffer()
+            }
+        }
+    }
+
+    private suspend fun pushAndClearBuffer() {
+        implPushResults(bufferedResults.toList())
+        bufferedResults.clear()
+    }
+
+    private fun addResultToBuffer(result: JobResult<*>) {
+        bufferedResults.add(result)
+        logger.debug(MARKER_RESULT_BUFFER) { "Added result of job '${result.jobId}' to buffer (size = ${bufferedResults.size})" }
+    }
+
+    companion object {
+        private val MARKER_RESULT_BUFFER = MarkerFactory.getMarker("ResultBuffer")
+
+        val TIMEOUT_RESULT_COLLECTION: Long = java.util.concurrent.TimeUnit.MINUTES.toMillis(2)
+    }
+}

--- a/ergo-service-sqs/src/main/kotlin/headout/oss/ergo/helpers/JobResultHandler.kt
+++ b/ergo-service-sqs/src/main/kotlin/headout/oss/ergo/helpers/JobResultHandler.kt
@@ -6,6 +6,12 @@ import kotlinx.coroutines.CoroutineScope
 /**
  * Created by shivanshs9 on 21/09/20.
  */
+
+/**
+ * Defines an handler to handle job result after execution
+ *
+ * It's upto the implementation to decide when to push the results
+ */
 interface JobResultHandler {
     fun init(scope: CoroutineScope, pushResultsImpl: suspend (List<JobResult<*>>) -> Unit)
 

--- a/ergo-service-sqs/src/main/kotlin/headout/oss/ergo/helpers/JobResultHandler.kt
+++ b/ergo-service-sqs/src/main/kotlin/headout/oss/ergo/helpers/JobResultHandler.kt
@@ -1,0 +1,13 @@
+package headout.oss.ergo.helpers
+
+import headout.oss.ergo.models.JobResult
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Created by shivanshs9 on 21/09/20.
+ */
+interface JobResultHandler {
+    fun init(scope: CoroutineScope, pushResultsImpl: suspend (List<JobResult<*>>) -> Unit)
+
+    suspend fun handleResult(result: JobResult<*>): Boolean
+}

--- a/ergo-service-sqs/src/test/kotlin/headout/oss/ergo/services/BaseSqsServiceTest.kt
+++ b/ergo-service-sqs/src/test/kotlin/headout/oss/ergo/services/BaseSqsServiceTest.kt
@@ -1,0 +1,82 @@
+package headout.oss.ergo.services
+
+import headout.oss.ergo.BaseTest
+import headout.oss.ergo.helpers.InMemoryBufferJobResultHandler
+import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.function.Consumer
+
+/**
+ * Created by shivanshs9 on 22/09/20.
+ */
+@ExperimentalCoroutinesApi
+abstract class BaseSqsServiceTest : BaseTest() {
+    protected val sqsClient: SqsAsyncClient = mockk(relaxed = true)
+    protected lateinit var msgService: SqsMsgService
+
+    override fun beforeTest() {
+        super.beforeTest()
+        msgService = spyk(createSqsMsgService())
+        mockkObject(BaseMsgService.Companion)
+        mockCommonSqsClient()
+    }
+
+    override fun afterTest() {
+        super.afterTest()
+        msgService.stop()
+    }
+
+    protected abstract fun createSqsMsgService(): SqsMsgService
+
+    private fun mockCommonSqsClient() {
+        val deleteSlot = slot<Consumer<DeleteMessageRequest.Builder>>()
+        every { sqsClient.deleteMessage(capture(deleteSlot)) } answers {
+            callOriginal()
+        }
+    }
+
+    protected fun mockReceiveMessageResponse(
+        jobId: String = "jobId",
+        taskId: String? = null,
+        body: String? = null,
+        receiptHandle: String = "receipt",
+        msgCount: Int = 1
+    ) {
+        val response = ReceiveMessageResponse.builder()
+            .messages(
+                List(msgCount) {
+                    Message.builder()
+                        .messageId("$jobId-$it")
+                        .apply {
+                            taskId?.let {
+                                attributes(mapOf(MessageSystemAttributeName.MESSAGE_GROUP_ID to it))
+                            }
+                        }
+                        .apply {
+                            body?.also { body(it) }
+                        }
+                        .receiptHandle(receiptHandle)
+                        .build()
+                }
+            )
+            .build()
+        every { sqsClient.receiveMessage(any<ReceiveMessageRequest>()) } returnsMany listOf<CompletableFuture<ReceiveMessageResponse>>(
+            CompletableFuture.completedFuture(response),
+            CompletableFuture.supplyAsync {
+                Thread.sleep(InMemoryBufferJobResultHandler.TIMEOUT_RESULT_COLLECTION * 2) // to ensure the error happens only after results are pushed
+                error("Dummy error to mark failure on receiving messages")
+            }
+        )
+    }
+
+    companion object {
+        const val QUEUE_URL = "sqs://queue"
+        const val DELAY_WAIT = 1000L
+
+        val VISIBILITY_TIMEOUT: Long = TimeUnit.SECONDS.toSeconds(5)
+    }
+}

--- a/ergo-service-sqs/src/test/kotlin/headout/oss/ergo/services/SqsMsgServiceWithBufferedResultsTest.kt
+++ b/ergo-service-sqs/src/test/kotlin/headout/oss/ergo/services/SqsMsgServiceWithBufferedResultsTest.kt
@@ -1,14 +1,14 @@
 package headout.oss.ergo.services
 
 import com.google.common.truth.Truth.assertThat
-import headout.oss.ergo.BaseTest
 import headout.oss.ergo.examples.WhyDisKolaveriDi
 import headout.oss.ergo.factory.JsonFactory
 import headout.oss.ergo.helpers.InMemoryBufferJobResultHandler
 import headout.oss.ergo.models.JobResult
 import headout.oss.ergo.models.JobResultMetadata
 import headout.oss.ergo.models.RequestMsg
-import io.mockk.*
+import io.mockk.coVerify
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -16,11 +16,9 @@ import kotlinx.serialization.ImplicitReflectionSerializer
 import kotlinx.serialization.stringify
 import mu.KotlinLogging
 import org.junit.Test
-import software.amazon.awssdk.services.sqs.SqsAsyncClient
-import software.amazon.awssdk.services.sqs.model.*
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.TimeUnit
-import java.util.function.Consumer
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
+import software.amazon.awssdk.services.sqs.model.Message
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest
 
 /**
  * Created by shivanshs9 on 02/06/20.
@@ -28,22 +26,9 @@ import java.util.function.Consumer
 private val logger = KotlinLogging.logger {}
 
 @ExperimentalCoroutinesApi
-class SqsMsgServiceWithBufferedResultsTest : BaseTest() {
-    private val sqsClient: SqsAsyncClient = mockk(relaxed = true)
-    private lateinit var msgService: SqsMsgService
-
-    override fun beforeTest() {
-        super.beforeTest()
-        msgService =
-            spyk(SqsMsgService(sqsClient, QUEUE_URL, defaultVisibilityTimeout = VISIBILITY_TIMEOUT, scope = testScope))
-        mockkObject(BaseMsgService.Companion)
-        mockCommonSqsClient()
-    }
-
-    override fun afterTest() {
-        super.afterTest()
-        msgService.stop()
-    }
+class SqsMsgServiceWithBufferedResultsTest : BaseSqsServiceTest() {
+    override fun createSqsMsgService(): SqsMsgService =
+        SqsMsgService(sqsClient, QUEUE_URL, defaultVisibilityTimeout = VISIBILITY_TIMEOUT, scope = testScope)
 
     @Test
     fun sufficientWorkersLaunchedOnStart() {
@@ -52,11 +37,13 @@ class SqsMsgServiceWithBufferedResultsTest : BaseTest() {
             assertThat(children.count()).isEqualTo(workersCount)
         }
         val countLauncher = 1
-        val countChannels = 2
+        val countChannels = 1
         val countWorkerSupervisor = 1
+        // using buffer result handler by default
+        val countBufferResultTimeoutTicker = 2
         assertThat(
             msgService.coroutineContext[Job]?.children?.count() ?: 0
-        ).isEqualTo(countChannels + countLauncher + countWorkerSupervisor)
+        ).isEqualTo(countChannels + countLauncher + countWorkerSupervisor + countBufferResultTimeoutTicker)
     }
 
     @Test
@@ -284,53 +271,5 @@ class SqsMsgServiceWithBufferedResultsTest : BaseTest() {
                 it.queueUrl() == QUEUE_URL && entries.size == msgCount
             })
         }
-    }
-
-    private fun mockCommonSqsClient() {
-        val deleteSlot = slot<Consumer<DeleteMessageRequest.Builder>>()
-        every { sqsClient.deleteMessage(capture(deleteSlot)) } answers {
-            callOriginal()
-        }
-    }
-
-    private fun mockReceiveMessageResponse(
-        jobId: String = "jobId",
-        taskId: String? = null,
-        body: String? = null,
-        receiptHandle: String = "receipt",
-        msgCount: Int = 1
-    ) {
-        val response = ReceiveMessageResponse.builder()
-            .messages(
-                List(msgCount) {
-                    Message.builder()
-                        .messageId("$jobId-$it")
-                        .apply {
-                            taskId?.let {
-                                attributes(mapOf(MessageSystemAttributeName.MESSAGE_GROUP_ID to it))
-                            }
-                        }
-                        .apply {
-                            body?.also { body(it) }
-                        }
-                        .receiptHandle(receiptHandle)
-                        .build()
-                }
-            )
-            .build()
-        every { sqsClient.receiveMessage(any<ReceiveMessageRequest>()) } returnsMany listOf<CompletableFuture<ReceiveMessageResponse>>(
-            CompletableFuture.completedFuture(response),
-            CompletableFuture.supplyAsync {
-                Thread.sleep(InMemoryBufferJobResultHandler.TIMEOUT_RESULT_COLLECTION * 2) // to ensure the error happens only after results are pushed
-                error("Dummy error to mark failure on receiving messages")
-            }
-        )
-    }
-
-    companion object {
-        private const val QUEUE_URL = "sqs://queue"
-        private const val DELAY_WAIT = 1000L
-
-        private val VISIBILITY_TIMEOUT: Long = TimeUnit.SECONDS.toSeconds(5)
     }
 }

--- a/ergo-service-sqs/src/test/kotlin/headout/oss/ergo/services/SqsMsgServiceWithImmediateResultTest.kt
+++ b/ergo-service-sqs/src/test/kotlin/headout/oss/ergo/services/SqsMsgServiceWithImmediateResultTest.kt
@@ -1,0 +1,97 @@
+package headout.oss.ergo.services
+
+import com.google.common.truth.Truth.assertThat
+import headout.oss.ergo.helpers.ImmediateRespondJobResultHandler
+import headout.oss.ergo.models.JobResult
+import io.mockk.coVerify
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import org.junit.Test
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest
+
+/**
+ * Created by shivanshs9 on 22/09/20.
+ */
+@ExperimentalCoroutinesApi
+class SqsMsgServiceWithImmediateResultTest : BaseSqsServiceTest() {
+    override fun createSqsMsgService(): SqsMsgService = SqsMsgService(
+        sqsClient,
+        QUEUE_URL,
+        defaultVisibilityTimeout = VISIBILITY_TIMEOUT,
+        resultHandler = ImmediateRespondJobResultHandler(),
+        scope = testScope
+    )
+
+    @Test
+    fun sufficientWorkersLaunchedOnStart() {
+        msgService.start().apply {
+            val workersCount = BaseMsgService.DEFAULT_NUMBER_WORKERS
+            assertThat(children.count()).isEqualTo(workersCount)
+        }
+        val countLauncher = 1
+        val countChannels = 1
+        val countWorkerSupervisor = 1
+        assertThat(
+            msgService.coroutineContext[Job]?.children?.count() ?: 0
+        ).isEqualTo(countChannels + countLauncher + countWorkerSupervisor)
+    }
+
+    @Test
+    fun whenWorkerEncounteredError_PushToResultQueue() {
+        val msgCount = 2
+        val taskId = "taskNotFound"
+        val receiptHandle = "receipt"
+        mockReceiveMessageResponse(taskId = taskId, body = "false", receiptHandle = receiptHandle, msgCount = msgCount)
+        msgService.start()
+        coVerify {
+            msgService.processRequest(any())
+            (1..msgCount).forEach { _ ->
+                delay(DELAY_WAIT)
+                msgService["pushResults"](match<List<JobResult<*>>> { it.size == 1 })
+            }
+        }
+    }
+
+    @Test
+    fun whenTaskRequestValidAndRanSuccessfully_PushToResultQueue() {
+        val msgCount = 2
+        val taskId = "xyz.1"
+        val body = "{\"i\": 1, \"hi\": \"whatever\"}"
+        mockReceiveMessageResponse(taskId = taskId, body = body, msgCount = msgCount)
+        msgService.start()
+        coVerify {
+            msgService.processRequest(any())
+            (1..msgCount).forEach { _ ->
+                delay(DELAY_WAIT)
+                msgService["pushResults"](match<List<JobResult<*>>> { it.size == 1 })
+            }
+        }
+    }
+
+    @Test
+    fun whenPushResultsCalled_BatchSendMessageToSqsQueue() {
+        val msgCount = 2
+        val taskId = "noArgWithSerializableResult"
+        val body = ""
+        mockReceiveMessageResponse(taskId = taskId, body = body, msgCount = msgCount)
+        msgService.start()
+        coVerify {
+            msgService.processRequest(any())
+            (1..msgCount).forEach { _ ->
+                delay(DELAY_WAIT)
+                msgService["pushResults"](match<List<JobResult<*>>> { it.size == 1 })
+            }
+        }
+        verify {
+            (1..msgCount).forEach { _ ->
+                sqsClient.sendMessageBatch(match<SendMessageBatchRequest> {
+                    val entries = it.entries()
+                    println(entries)
+                    it.queueUrl() == QUEUE_URL && entries.size == 1
+                })
+            }
+        }
+    }
+}

--- a/ergo-spring/src/main/kotlin/headout/oss/ergo/factory/SpringInstanceLocator.kt
+++ b/ergo-spring/src/main/kotlin/headout/oss/ergo/factory/SpringInstanceLocator.kt
@@ -6,6 +6,10 @@ import kotlin.reflect.KClass
 /**
  * Created by shivanshs9 on 13/07/20.
  */
+
+/**
+ * Supports spring beans and gets the instance using cached spring application context
+ */
 class SpringInstanceLocator : InstanceLocator {
     override fun <T : Any> getInstance(clazz: KClass<T>): T? {
         val isSpringBean = clazz.annotations.filter {

--- a/ergo-spring/src/main/kotlin/headout/oss/ergo/spring/SpringContext.kt
+++ b/ergo-spring/src/main/kotlin/headout/oss/ergo/spring/SpringContext.kt
@@ -1,5 +1,6 @@
 package headout.oss.ergo.spring
 
+import headout.oss.ergo.spring.SpringContext.Companion.getBean
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import org.springframework.stereotype.Component
@@ -7,6 +8,11 @@ import kotlin.reflect.KClass
 
 /**
  * Created by shivanshs9 on 13/07/20.
+ */
+
+/**
+ * Spring [Component] to store the spring's [ApplicationContext] as a static field
+ * and provide a [getBean] method to get spring bean instance using the context
  */
 @Component
 class SpringContext : ApplicationContextAware {
@@ -17,6 +23,9 @@ class SpringContext : ApplicationContextAware {
     companion object {
         private lateinit var context: ApplicationContext
 
+        /**
+         * Returns a spring bean instance of the given class
+         */
         fun <T : Any> getBean(beanClazz: KClass<T>): T = context.getBean(beanClazz.java)
     }
 }

--- a/sample/src/main/kotlin/headout/oss/ergo/Runtime.kt
+++ b/sample/src/main/kotlin/headout/oss/ergo/Runtime.kt
@@ -1,5 +1,6 @@
 package headout.oss.ergo
 
+import headout.oss.ergo.helpers.ImmediateRespondJobResultHandler
 import headout.oss.ergo.services.SqsMsgService
 import kotlinx.coroutines.*
 import software.amazon.awssdk.regions.Region
@@ -53,7 +54,13 @@ fun main() = runBlocking {
         .endpointOverride(LOCAL_ENDPOINT)
         .region(LOCAL_REGION)
         .build()
-    val service = SqsMsgService(sqsClient, QUEUE_URL, RESULT_QUEUE_URL)
+    val service = SqsMsgService(
+        sqsClient,
+        QUEUE_URL,
+        RESULT_QUEUE_URL,
+        numWorkers = 20,
+        resultHandler = ImmediateRespondJobResultHandler()
+    )
     val cronJob = service.start()
     Runtime.getRuntime().addShutdownHook(object : Thread() {
         override fun run() {


### PR DESCRIPTION
Gives flexibility to library's client:
- different implementation can decide whether to buffer results (in-memory, redis) or send as soon as its done

Tests:
- [x] For buffering of results
- [x] For immediate result responder