### PR TITLE
increases the capture worker to 8 from 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ gradle-app.setting
 
 # End of https://www.gitignore.io/api/git,java,linux,kotlin,intellij,gradle
 /local.properties
+
+# random .idea files
+.idea/*

--- a/ergo-runtime/src/main/kotlin/headout/oss/ergo/services/BaseMsgService.kt
+++ b/ergo-runtime/src/main/kotlin/headout/oss/ergo/services/BaseMsgService.kt
@@ -120,6 +120,7 @@ abstract class BaseMsgService<T>(
         val jobController: BaseJobController = JobController
 
         const val DEFAULT_NUMBER_WORKERS = 8
+        const val DEFAULT_NUMBER_CAPTURE_WORKERS = 8
         const val CAPACITY_CAPTURE_BUFFER = 40
         const val CAPACITY_REQUEST_BUFFER = 20
 

--- a/gradle/common.gradle.kts
+++ b/gradle/common.gradle.kts
@@ -1,4 +1,4 @@
-val VERSION_NAME = "1.3.2"
+val VERSION_NAME = "1.3.4"
 
 version = VERSION_NAME
 group = "headout.oss"


### PR DESCRIPTION
1. Result Capture workers(coroutines) increased from 1 to 8 to reduce delay in processing results & visibility timeout handling
2. Check added before processing jobs to skip if already present in pending jobs set.
3. Updates delay logic of PingMessageCapture to consider updated visibility timeout instead of default.